### PR TITLE
fix: issue #3. add private constructor for Mapping class.

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/viewmodels/Mapping.java
+++ b/src/main/java/de/dennisguse/opentracks/viewmodels/Mapping.java
@@ -10,6 +10,11 @@ import de.dennisguse.opentracks.R;
 
 public class Mapping {
 
+    // Private constructor to hide the implicit public one
+    private Mapping() {
+        throw new IllegalStateException("Utility class");
+    }
+
     public static Map<String, Callable<StatisticViewHolder<?>>> create(Context context) {
         HashMap<String, Callable<StatisticViewHolder<?>>> m = new HashMap<>();
         m.put(context.getString(R.string.stats_custom_layout_total_time_key), GenericStatisticsViewHolder.TotalTime::new);


### PR DESCRIPTION
Issue Title:
Add a private constructor to hide the implicit public one in the Mapping class

Description:
The Mapping class currently lacks a private constructor, allowing it to be instantiated implicitly. To follow best practices and prevent unintended instantiation, we should add a private constructor to the class.

https://github.com/Shrutipavasiya/OpenTracks-Winter-SOEN-6431_2024/issues/3

