### PR TITLE
Issue #92 added a few preventive maintenance on the total number of days used for the chairlift feature and a back button taking the user to the previous activity. Also added the same color code on the fragment_chairs_stats layout to respect Professor Rilling prototype on the requirements document

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/ui/aggregatedStatistics/SeasonStats/ChairsStatFragment.java
+++ b/src/main/java/de/dennisguse/opentracks/ui/aggregatedStatistics/SeasonStats/ChairsStatFragment.java
@@ -5,6 +5,8 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
+import android.widget.ImageButton;
+
 
 import androidx.fragment.app.Fragment;
 
@@ -78,6 +80,17 @@ public class ChairsStatFragment extends Fragment {
         TextView favoriteChairsTextView4 = view.findViewById(R.id.favChairTextView4);
         TextView favoriteChairsTextView5 = view.findViewById(R.id.favChairTextView5);
 
+         // Find the ImageButton by its ID
+         ImageButton backButton = view.findViewById(R.id.imageButton);
+                 // Set OnClickListener to handle the click event
+        backButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                // Finish the current activity to go back to the previous one
+                getActivity().finish();
+            }
+        });
+
         if (seasonNameTextView != null && mSeasonName != null) {
             seasonNameTextView.setText(mSeasonName);
             daysTextView.setText(mDays);
@@ -93,4 +106,5 @@ public class ChairsStatFragment extends Fragment {
         }
         return view;
     }
+    
 }

--- a/src/main/java/de/dennisguse/opentracks/ui/aggregatedStatistics/SeasonStats/RunAndChairStatActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/ui/aggregatedStatistics/SeasonStats/RunAndChairStatActivity.java
@@ -72,7 +72,7 @@ public class RunAndChairStatActivity extends AppCompatActivity {
                 distance = Integer.toString((int)intent.getDoubleExtra("distance", -1.0));
                 max_Speed = Integer.toString((int)intent.getDoubleExtra("max_Speed", -1.0));
                 longestRun = Integer.toString((int)intent.getDoubleExtra("longestRun", -1.0));
-                totalNumberOfDaysChairliftUsed = Integer.toString((int)intent.getDoubleExtra("totalNumberOfDaysChairliftUsed",-1));
+                totalNumberOfDaysChairliftUsed = Integer.toString((int)intent.getDoubleExtra("totalNumberOfDaysChairliftUsed",-1.0));
 
             }
             // Pass the string as an argument if the fragment is RunsStatFragment
@@ -96,5 +96,11 @@ public class RunAndChairStatActivity extends AppCompatActivity {
             fragmentTransaction.replace(R.id.frame_nav_season, ChairsStatFragment.newInstance(seasonName, mostCommonTrail, days, tallestChair, totalDaysChairliftUsed, favoriteChairs));
         }
         fragmentTransaction.commit();
+    }
+
+    @Override
+    public void onBackPressed() {
+        // Perform the default back button behavior (e.g., navigate back)
+        super.onBackPressed();
     }
 }

--- a/src/main/java/de/dennisguse/opentracks/ui/aggregatedStatistics/SeasonStats/SeasonStatActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/ui/aggregatedStatistics/SeasonStats/SeasonStatActivity.java
@@ -66,6 +66,11 @@ public class SeasonStatActivity extends AppCompatActivity {
             }
         });
     }
+
+    @Override
+    public void onBackPressed() {
+        finish();
+    }
 }
 
 //This class is each item in the list class which in our case is seasons. this is a dummy class just to have items You should use seasons in the code not ListItem class.

--- a/src/main/res/layout/fragment_chairs_stat.xml
+++ b/src/main/res/layout/fragment_chairs_stat.xml
@@ -13,19 +13,22 @@
         tools:context=".ui.aggregatedStatistics.SeasonStats.RunAndChairStatActivity">
 
         <!-- Season Name TextView -->
+
+        <!-- Season Totals TextView -->
         <TextView
             android:id="@+id/seasonNameTextView"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:background="@android:color/holo_blue_light"
             android:gravity="center"
             android:text="@string/season_name"
             android:textSize="30dp"
             android:textStyle="bold"
             app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.0"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <!-- Season Totals TextView -->
         <TextView
             android:id="@+id/textView4"
             android:layout_width="match_parent"
@@ -209,21 +212,20 @@
             android:id="@+id/season_common_trail"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginTop="9sp"
             android:text="@string/season_common_trail"
             android:textSize="18sp"
             android:textStyle="bold"
-            android:layout_marginTop="9sp"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/row11"
-            />
+            app:layout_constraintTop_toBottomOf="@+id/row11" />
 
         <LinearLayout
             android:id="@+id/row13"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical"
             android:layout_marginTop="6sp"
+            android:orientation="vertical"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/season_common_trail">
@@ -232,14 +234,25 @@
                 android:id="@+id/name_of_common_trail"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
+                android:layout_marginStart="5dp"
                 android:text="@string/name_of_common_trail"
                 android:textSize="16sp"
-                android:layout_marginStart="5dp"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/season_common_trail" />
 
         </LinearLayout>
+
+        <ImageButton
+            android:id="@+id/imageButton"
+            android:layout_width="60dp"
+            android:layout_height="35dp"
+            android:background="@android:color/holo_blue_light"
+            android:src="@drawable/ic_baseline_arrow_back_24"
+            app:layout_constraintBottom_toTopOf="@+id/textView4"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="0.0"
+            tools:layout_editor_absoluteX="-8dp" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 


### PR DESCRIPTION
# Thanks for your contribution.

## PLEASE REMOVE
To support us in providing a nice (and fast) open-source experience:
1. Verify that the tests are passing
2. Check that the code is properly formatted (using AndroidStudio's autoformatter)
3. Provide write access to the [branch](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
4. If the PR is not ready for review, please submit it as a [draft](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
## PLEASE REMOVE

**Describe the pull request**
A clear and concise description of what the pull request changes/adds.

**Link to the the issue**
(If available): The link to the issue that this pull request solves.

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).

**Note: new dependencies/libraries**
Please refrain from introducing new libraries without consulting the team.
